### PR TITLE
First-Class Mail fixes

### DIFF
--- a/ShippingRates.Tests/ShippingProviders/USPSProviderTests.cs
+++ b/ShippingRates.Tests/ShippingProviders/USPSProviderTests.cs
@@ -222,5 +222,23 @@ namespace ShippingRates.Tests.ShippingProviders
                 Debug.WriteLine(rate.Name + ": " + rate.TotalCharges);
             }
         }
+
+        [Test]
+        public async Task USPS_ThreeAndAHalfOunceLetter_Qualifies_For_First_Class_Mail_Letter()
+        {
+            var rateManager = new RateManager();
+            rateManager.AddProvider(new USPSProvider(_uspsUserId));
+
+            const decimal firstClassLetterMaxWeight = 0.21875m; // 3.5 ounces
+            var firstClassLetter = new DocumentsPackage(firstClassLetterMaxWeight, 0);
+
+            var origin = new Address("", "", "06405", "US");
+            var destination = new Address("", "", "20852", "US");
+
+            var response = await rateManager.GetRatesAsync(origin, destination, firstClassLetter);
+
+            Assert.True(response.Rates.Any(r =>
+                r.ProviderCode is "First-Class Mail Stamped Letter" or "First-Class Mail Metered Letter"));
+        }
     }
 }

--- a/ShippingRates.Tests/Units/PackageTests.cs
+++ b/ShippingRates.Tests/Units/PackageTests.cs
@@ -7,13 +7,15 @@ namespace ShippingRates.Tests.Units
     {
         [Theory]
         [TestCase(3.5, 3, 8)]
-        [TestCase(5.8, 5, 13)]
-        [TestCase(6.2, 6, 4)]
-        public void PoundsAndOuncesCalculatedCorrectly(decimal weight, int pounds, int ounces)
+        [TestCase(5.8, 5, 12.8)]
+        [TestCase(6.2, 6, 3.2)]
+        [TestCase(0.21875, 0, 3.5)]
+        [TestCase(0.8125, 0, 13)]
+        public void PoundsAndOuncesCalculatedCorrectly(decimal weight, int pounds, decimal ounces)
         {
             var package = new Package(1, 2, 3, weight, 100);
-            Assert.AreEqual(package.PoundsAndOunces.Pounds, pounds);
-            Assert.AreEqual(package.PoundsAndOunces.Ounces, ounces);
+            Assert.AreEqual(pounds, package.PoundsAndOunces.Pounds);
+            Assert.AreEqual(ounces, package.PoundsAndOunces.Ounces);
         }
     }
 }

--- a/ShippingRates/Package.cs
+++ b/ShippingRates/Package.cs
@@ -86,9 +86,7 @@ namespace ShippingRates
                 }
 
                 poundsAndOunces.Pounds = (int) Math.Truncate(Weight);
-                var decimalPart = (Weight - poundsAndOunces.Pounds) * 16;
-
-                poundsAndOunces.Ounces = (int) Math.Ceiling(decimalPart);
+                poundsAndOunces.Ounces = (Weight - poundsAndOunces.Pounds) * 16;
 
                 return poundsAndOunces;
             }

--- a/ShippingRates/PoundsAndOunces.cs
+++ b/ShippingRates/PoundsAndOunces.cs
@@ -6,6 +6,6 @@
     public struct PoundsAndOunces
     {
         public int Pounds { get; set; }
-        public int Ounces { get; set; }
+        public decimal Ounces { get; set; }
     }
 }

--- a/ShippingRates/ShippingProviders/USPSInternationalProvider.cs
+++ b/ShippingRates/ShippingProviders/USPSInternationalProvider.cs
@@ -129,8 +129,8 @@ namespace ShippingRates.ShippingProviders
                     writer.WriteAttributeString("ID", i.ToString());
                     writer.WriteElementString("Pounds", package.PoundsAndOunces.Pounds.ToString());
                     writer.WriteElementString("Ounces", package.PoundsAndOunces.Ounces.ToString());
-                    writer.WriteElementString("MailType", "Package");
-                    writer.WriteElementString("ValueOfContents", package.InsuredValue < 0 ? package.InsuredValue.ToString() : "100"); //todo: figure out best way to come up with insured value
+                    writer.WriteElementString("MailType", "All");
+                    writer.WriteElementString("ValueOfContents", package.InsuredValue.ToString());
                     writer.WriteElementString("Country", Shipment.DestinationAddress.GetCountryName());
                     writer.WriteElementString("Container", "RECTANGULAR");
                     writer.WriteElementString("Size", "REGULAR");
@@ -140,6 +140,15 @@ namespace ShippingRates.ShippingProviders
                     writer.WriteElementString("Girth", package.CalculatedGirth.ToString());
                     writer.WriteElementString("OriginZip", Shipment.OriginAddress.PostalCode);
                     writer.WriteElementString("CommercialFlag", Commercial ? "Y" : "N");
+
+                    // ContentType must be set to Documents to get First-Class International Mail rates
+                    if (package is DocumentsPackage)
+                    {
+                        writer.WriteStartElement("Content");
+                        writer.WriteElementString("ContentType", "Documents");
+                        writer.WriteEndElement();
+                    }
+
                     //TODO: Figure out DIM Weights
                     //writer.WriteElementString("Size", package.IsOversize ? "LARGE" : "REGULAR");
                     //writer.WriteElementString("Length", package.RoundedLength.ToString());


### PR DESCRIPTION
Hi Alexey,

Thanks for your work on this library. It's saved me lots of time!

I have some proposed fixes for issues I discovered with First-Class Mail rates:

1. **Change PoundsAndOunces.Ounces to a decimal.** Current behavior is to round up to the nearest integer. But this causes letters that should be eligible for First-Class Mail Letter pricing (up to 3.5oz) to be priced as 4 oz letters instead.

2. **Allow First-Class Mail International rates to be returned (both letter and large envelope)**. This requires 3 changes to `USPSInternationalProvider`:

   - Change the `MailType` to `All`. Current setting of `Package` seems to exclude "Letter" and "Large Envelope" rates.
   - Allow `ValueOfContents` to be set to 0. Insurance is apparently not available for First-Class Mail International.
   - Set `ContentType` to `Documents` if the package is a `DocumentPackage`. [Per USPS](https://www.usps.com/business/web-tools-apis/archive/2018-web-tools-release-notes.pdf), "First Class Mail International Letters and Flats content limited to documents".