### PR TITLE
Add option to set FedEx packaging when using OneRate

### DIFF
--- a/ShippingRates.Tests/ShippingProviders/FedExShipRates.cs
+++ b/ShippingRates.Tests/ShippingProviders/FedExShipRates.cs
@@ -103,10 +103,32 @@ namespace ShippingRates.Tests.ShippingProviders
             var to = new Address("Fitchburg", "WI", "53711", "US");
             var package = new Package(7, 7, 7, 6, 1);
 
+
             var rates = _rateManager.GetRates(from, to, package);
             var oneRates = _rateManagerNegotiated.GetRates(from, to, package, new ShipmentOptions()
             {
                 FedExOneRate = true
+            });
+
+            AssertRatesAreNotEqual(rates, oneRates);
+        }
+
+        [Test]
+        public void FedExOneRatePackage()
+        {
+            var from = new Address("Annapolis", "MD", "21401", "US");
+            var to = new Address("Fitchburg", "WI", "53711", "US");
+            var package = new Package(7, 7, 7, 6, 1);
+
+            var rates = _rateManagerNegotiated.GetRates(from, to, package, new ShipmentOptions()
+            {
+                FedExOneRate = true,
+                //if not set, will default to FEDEX_MEDIUM_BOX
+            });
+            var oneRates = _rateManagerNegotiated.GetRates(from, to, package, new ShipmentOptions()
+            {
+                FedExOneRate = true,
+                FedExOneRatePackageOverride ="FEDEX_ENVELOPE" //one of the cheapest options
             });
 
             AssertRatesAreNotEqual(rates, oneRates);

--- a/ShippingRates/Models/ShipmentOptions.cs
+++ b/ShippingRates/Models/ShipmentOptions.cs
@@ -21,8 +21,23 @@ namespace ShippingRates
         /// </summary>
         public string PreferredCurrencyCode { get; set; }
         /// <summary>
-        /// Use FedEx One Rate pricing option. Ignored for non-FedEx prodivers
+        /// Use FedEx One Rate pricing option. Ignored for non-FedEx providers
         /// </summary>
         public bool FedExOneRate { get; set; }
+        /// <summary>
+        /// For FedEx One Rate pricing option, allows ability to specify FedEx-specific packages:
+        /// FEDEX_10KG_BOX
+        /// FEDEX_25KG_BOX
+        /// FEDEX_BOX
+        /// FEDEX_ENVELOPE
+        /// FEDEX_EXTRA_LARGE_BOX
+        /// FEDEX_LARGE_BOX
+        /// FEDEX_MEDIUM_BOX
+        /// FEDEX_PAK
+        /// FEDEX_SMALL_BOX
+        /// FEDEX_TUBE
+        /// Ignored for non-FedEx providers.  Not applied uness FedExOneRate is true.
+        /// </summary>
+        public string FedExOneRatePackageOverride { get; set; }
     }
 }

--- a/ShippingRates/ShippingProviders/FedExBaseProvider.cs
+++ b/ShippingRates/ShippingProviders/FedExBaseProvider.cs
@@ -86,7 +86,14 @@ namespace ShippingRates.ShippingProviders
 
             if (Shipment.Options.FedExOneRate)
             {
-                request.RequestedShipment.PackagingType = "FEDEX_MEDIUM_BOX";
+                if (!string.IsNullOrEmpty(Shipment.Options.FedExOneRatePackageOverride))
+                {
+                    request.RequestedShipment.PackagingType = Shipment.Options.FedExOneRatePackageOverride;
+                }
+                else
+                {
+                    request.RequestedShipment.PackagingType = "FEDEX_MEDIUM_BOX";
+                }
                 request.RequestedShipment.SpecialServicesRequested = new ShipmentSpecialServicesRequested()
                 {
                     SpecialServiceTypes = new[] { "FEDEX_ONE_RATE" }


### PR DESCRIPTION
FedEx packaging options can affect the rates returned when specifying OneRate, rather than using YOUR_PACKAGING.

- Add override setting in ShipmentOptions
- Check override setting and apply when OneRate is specified