### PR TITLE
Public API cleanups

### DIFF
--- a/ShippingRates/Helpers/Extensions/ShipmentOptionsExtensions.cs
+++ b/ShippingRates/Helpers/Extensions/ShipmentOptionsExtensions.cs
@@ -2,7 +2,7 @@
 {
     internal static class ShipmentOptionsExtensions
     {
-        public static string GetCurrencyCode(this ShipmentOptions options)
+        internal static string GetCurrencyCode(this ShipmentOptions options)
         {
             return !string.IsNullOrEmpty(options?.PreferredCurrencyCode)
                 ? options.PreferredCurrencyCode

--- a/ShippingRates/Models/PackageDimension.cs
+++ b/ShippingRates/Models/PackageDimension.cs
@@ -33,7 +33,7 @@ namespace ShippingRates.Models
             {
                 return _value * 0.393701m;
             }
-            throw new Exception($"Unsupported size conversion from {_unitsSystem} to {unitsSystem}");
+            throw new NotSupportedException($"Unsupported size conversion from {_unitsSystem} to {unitsSystem}");
         }
 
         public decimal GetRounded(UnitsSystem unitsSystem) => Math.Ceiling(Get(unitsSystem));

--- a/ShippingRates/Models/ShipmentOptions.cs
+++ b/ShippingRates/Models/ShipmentOptions.cs
@@ -5,7 +5,7 @@ namespace ShippingRates
 {
     public class ShipmentOptions
     {
-        public const string DefaultCurrencyCode = "USD";
+        public static readonly string DefaultCurrencyCode = "USD";
 
         /// <summary>
         /// Enable Saturday Delivery option for shipping rates

--- a/ShippingRates/Services/OAuth/OAuthMessages.cs
+++ b/ShippingRates/Services/OAuth/OAuthMessages.cs
@@ -4,15 +4,15 @@ internal static class OAuthMessages
 {
     internal static class Debug
     {
-        public const string TokenFetchedFromCache = "Fetched {ServiceName} token from cache for clientId {ClientId}";
-        public const string TokenReceived = "Received OAuth token from {ServiceName}";
+        internal const string TokenFetchedFromCache = "Fetched {ServiceName} token from cache for clientId {ClientId}";
+        internal const string TokenReceived = "Received OAuth token from {ServiceName}";
     }
 
     internal static class Error
     {
-        public const string ClientIdMissing = "ClientId is required.";
-        public const string TokenErrorWithCode = "Error while fetching {ServiceName} OAuth token. Provider returned {Code}: {Message}";
-        public const string TokenError = "Error while fetching {ServiceName} OAuth token. Provider returned: {Message}";
-        public const string Unknown = "Unexpected response fetching {ServiceName} OAuth token. Status {StatusCode}, body: {Response}";
+        internal const string ClientIdMissing = "ClientId is required.";
+        internal const string TokenErrorWithCode = "Error while fetching {ServiceName} OAuth token. Provider returned {Code}: {Message}";
+        internal const string TokenError = "Error while fetching {ServiceName} OAuth token. Provider returned: {Message}";
+        internal const string Unknown = "Unexpected response fetching {ServiceName} OAuth token. Status {StatusCode}, body: {Response}";
     }
 }

--- a/ShippingRates/ShippingProviders/Dhl/DHLProvider.cs
+++ b/ShippingRates/ShippingProviders/Dhl/DHLProvider.cs
@@ -22,7 +22,7 @@ namespace ShippingRates.ShippingProviders
     {
         public override string Name { get => "DHL"; }
 
-        public static Dictionary<char, string> AvailableServices => new Dictionary<char, string>
+        private static readonly IReadOnlyDictionary<char, string> _availableServices = new Dictionary<char, string>
         {
             { '1', "EXPRESS DOMESTIC 12:00" },
             { '4', "JETLINE" },
@@ -55,7 +55,9 @@ namespace ShippingRates.ShippingProviders
             { 'Y', "EXPRESS 12:00" }
         };
 
-        public const int DefaultTimeout = 10;
+        public static IReadOnlyDictionary<char, string> AvailableServices => _availableServices;
+
+        public static readonly int DefaultTimeout = 10;
 
         private readonly DHLProviderConfiguration _configuration;
 

--- a/ShippingRates/ShippingProviders/FedEx/FedExBaseProvider.cs
+++ b/ShippingRates/ShippingProviders/FedEx/FedExBaseProvider.cs
@@ -17,9 +17,9 @@ public abstract class FedExBaseProvider<T> : AbstractShippingProvider where T : 
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
         if (string.IsNullOrEmpty(_configuration.ClientId))
-            throw new Exception("ClientId is required");
+            throw new ArgumentException("ClientId is required.", nameof(configuration));
         if (string.IsNullOrEmpty(_configuration.ClientSecret))
-            throw new Exception("ClientSecret is required");
+            throw new ArgumentException("ClientSecret is required.", nameof(configuration));
     }
 
     public FedExBaseProvider(FedExProviderConfiguration configuration, HttpClient httpClient)
@@ -50,7 +50,7 @@ public abstract class FedExBaseProvider<T> : AbstractShippingProvider where T : 
     /// Gets service codes.
     /// </summary>
     /// <returns></returns>
-    public IDictionary<string, string> GetServiceCodes() => ServiceCodes;
+    public IReadOnlyDictionary<string, string> GetServiceCodes() => ServiceCodes;
 
     public static string GetRequestUri(bool isProduction)
         => $"https://{(isProduction ? "apis" : "apis-sandbox")}.fedex.com";

--- a/ShippingRates/ShippingProviders/Messages.cs
+++ b/ShippingRates/ShippingProviders/Messages.cs
@@ -10,8 +10,8 @@ namespace ShippingRates.ShippingProviders
     {
         internal static class Information
         {
-            public const string DeserializationFailed = "Unable to deserialize response.";
-            public const string UnknownError = "Unknown error '{Message}' while fetching prices: {StatusCode} {Response}";
+            internal const string DeserializationFailed = "Unable to deserialize response.";
+            internal const string UnknownError = "Unknown error '{Message}' while fetching prices: {StatusCode} {Response}";
         }
     }
 }

--- a/ShippingRates/ShippingProviders/Ups/UPSProvider.cs
+++ b/ShippingRates/ShippingProviders/Ups/UPSProvider.cs
@@ -19,7 +19,7 @@ public class UPSProvider : AbstractShippingProvider
     readonly UPSProviderConfiguration _configuration;
     readonly ILogger<UPSProvider>? _logger;
 
-    readonly static Dictionary<string, string> _serviceCodes = new Dictionary<string, string>()
+    static readonly IReadOnlyDictionary<string, string> _serviceCodes = new Dictionary<string, string>()
     {
         { "01", "UPS Next Day Air" },
         { "02", "UPS Second Day Air" },
@@ -44,11 +44,11 @@ public class UPSProvider : AbstractShippingProvider
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
 
         if (string.IsNullOrEmpty(_configuration.ClientId))
-            throw new Exception("ClientId is required");
+            throw new ArgumentException("ClientId is required.", nameof(configuration));
         if (string.IsNullOrEmpty(_configuration.ClientSecret))
-            throw new Exception("ClientSecret is required");
+            throw new ArgumentException("ClientSecret is required.", nameof(configuration));
         if (string.IsNullOrEmpty(_configuration.AccountNumber))
-            throw new Exception("AccountNumber is required");
+            throw new ArgumentException("AccountNumber is required.", nameof(configuration));
     }
 
     public UPSProvider(UPSProviderConfiguration configuration, HttpClient httpClient)
@@ -180,5 +180,5 @@ public class UPSProvider : AbstractShippingProvider
         }
     }
 
-    public static IDictionary<string, string> GetServiceCodes() => _serviceCodes;
+    public static IReadOnlyDictionary<string, string> GetServiceCodes() => _serviceCodes;
 }

--- a/ShippingRates/ShippingProviders/Usps/UspsMessages.cs
+++ b/ShippingRates/ShippingProviders/Usps/UspsMessages.cs
@@ -4,10 +4,10 @@ internal static class UspsMessages
 {
     internal static class Error
     {
-        public const string DeserializationFailed = "Unable to deserialize USPS response.";
-        public const string UspsError = "USPS Error: {Message}";
-        public const string UspsErrorWithCode = "USPS Error: {Code} {Message}";
-        public const string UnknownError = "Unknown error '{Message}' while fetching USPS prices: {StatusCode} {Response}";
-        public const string ErrorOriginNotUS = "USPS supports only shipments with an origin address in the United States.";
+        internal const string DeserializationFailed = "Unable to deserialize USPS response.";
+        internal const string UspsError = "USPS Error: {Message}";
+        internal const string UspsErrorWithCode = "USPS Error: {Code} {Message}";
+        internal const string UnknownError = "Unknown error '{Message}' while fetching USPS prices: {StatusCode} {Response}";
+        internal const string ErrorOriginNotUS = "USPS supports only shipments with an origin address in the United States.";
     }
 }


### PR DESCRIPTION
- Tighten internal-only constant visibility and avoid exposing implementation details as public members
- Switch public constants to static readonly and return read-only service code dictionaries
- Replace generic exceptions with more specific exception types for invalid configuration and unsupported conversions