### PR TITLE
Allow for tracing FedEx API request/responses

### DIFF
--- a/ShippingRates/Helpers/Extensions/LoggerExtensions.cs
+++ b/ShippingRates/Helpers/Extensions/LoggerExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace ShippingRates.Helpers.Extensions
+{
+    internal static class LoggerExtensions
+    {
+        internal static void TraceJson<T>(this ILogger<T> logger, string message, object obj)
+        {
+            if (logger.IsEnabled(LogLevel.Trace))
+            {
+                logger.LogTrace("{message}: {obj}", message, System.Text.Json.JsonSerializer.Serialize(obj));
+            }
+        }
+    }
+}

--- a/ShippingRates/ShippingProviders/FedEx/FedExRateTransmitTimesBaseProvider.cs
+++ b/ShippingRates/ShippingProviders/FedEx/FedExRateTransmitTimesBaseProvider.cs
@@ -247,6 +247,9 @@ namespace ShippingRates.ShippingProviders.FedEx
                     {
                         BaseUrl = GetRequestUri(_configuration.UseProduction)
                     };
+
+                    _logger?.TraceJson("FedEx rate request", request);
+
                     var reply = await service.Rate_and_Transit_timesAsync(
                         request,
                         DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(),
@@ -258,6 +261,8 @@ namespace ShippingRates.ShippingProviders.FedEx
 
                     if (reply.Output != null)
                     {
+                        _logger?.TraceJson("FedEx rate response", reply.Output);
+
                         ProcessReply(resultBuilder, shipment, reply.Output);
                     }
                     else


### PR DESCRIPTION
Now if you want to debug a FedEx API rate issue, all you need to do is enable the trace logging level, either globally or just for this namespace. This will emit a detailed log of the requests and responses from the FedEx API.

To avoid serializing the request/response JSON from every API call, a new extension method was added which only executes if the log level is set to trace.