### PR TITLE
Added missing fedex international connect plus service code

### DIFF
--- a/ShippingRates/ShippingProviders/FedEx/FedExProvider.cs
+++ b/ShippingRates/ShippingProviders/FedEx/FedExProvider.cs
@@ -45,6 +45,7 @@ public class FedExProvider : FedExRateTransmitTimesBaseProvider<FedExProvider>
         {"EUROPE_FIRST_INTERNATIONAL_PRIORITY", "FedEx International Priority" },
         {"FEDEX_INTERNATIONAL_PRIORITY", "FedEx International Priority" },
         {"FEDEX_INTERNATIONAL_PRIORITY_EXPRESS", "FedEx International Priority Express" },
+        {"FEDEX_INTERNATIONAL_CONNECT_PLUS", "FedEx International Connect Plus" },
         // Freight
         {"FEDEX_FIRST_FREIGHT", "FedEx First Freight" },
         {"FEDEX_1_DAY_FREIGHT", "FedEx 1 Day Freight" },


### PR DESCRIPTION
A client requested support for FedEx International Connect Plus rates, and while investigating I noticed that the corresponding service code was missing from the repository.

This PR adds the missing service code so rates for this service can be retrieved correctly.