### PR TITLE
Tolerate out-of-spec USPS priceType values in Domestic Prices response

### DIFF
--- a/ShippingRates.Tests/Models/Usps/UspsResponsePriceTypeDeserializationTests.cs
+++ b/ShippingRates.Tests/Models/Usps/UspsResponsePriceTypeDeserializationTests.cs
@@ -1,0 +1,117 @@
+using ShippingRates.Models.Usps;
+using System.Text.Json;
+
+namespace ShippingRates.Tests.Models.Usps;
+
+/// <summary>
+/// USPS's published Domestic Prices spec defines <c>priceType</c> as a fixed enum
+/// (RETAIL, COMMERCIAL, COMMERCIAL_BASE, COMMERCIAL_PLUS, CONTRACT, NSA), but the
+/// live API sometimes returns out-of-spec tokens such as <c>"N"</c> — an apparent
+/// USPS defect. A strict
+/// <see cref="System.Text.Json.Serialization.JsonStringEnumConverter"/> throws on
+/// those tokens, which aborts deserialization of the whole response and drops every rate.
+/// These tests verify documented values still parse to a real member, while out-of-spec
+/// tokens map to null so the rate is preserved instead of throwing.
+/// </summary>
+[TestFixture]
+public class UspsResponsePriceTypeDeserializationTests
+{
+    [Test]
+    public void GetDomesticPrices_WithUnknownPriceType_DoesNotThrowAndKeepsRates()
+    {
+        // "N" is an undocumented marketing-mail token that is not a member of
+        // UspsResponsePriceType.
+        const string json = """
+        {
+            "rateOptions": [
+                {
+                    "totalBasePrice": 8.10,
+                    "rates": [
+                        {
+                            "SKU": "DUGA0",
+                            "description": "USPS Ground Advantage",
+                            "priceType": "COMMERCIAL",
+                            "price": 8.10,
+                            "weight": 5.0,
+                            "mailClass": "USPS_GROUND_ADVANTAGE"
+                        },
+                        {
+                            "SKU": "NPGA0",
+                            "description": "USPS Marketing Mail Nonprofit",
+                            "priceType": "N",
+                            "price": 7.55,
+                            "weight": 5.0,
+                            "destinationEntryFacilityType": "SOME_NEW_FACILITY",
+                            "mailClass": "USPS_GROUND_ADVANTAGE"
+                        }
+                    ]
+                }
+            ]
+        }
+        """;
+
+        UspsPricesResponse? response = null;
+        Assert.DoesNotThrow(() =>
+            response = JsonSerializer.Deserialize<UspsPricesResponse>(json));
+
+        Assert.That(response, Is.Not.Null);
+        var rates = response!.RateOptions![0].Rates!;
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(rates, Has.Count.EqualTo(2), "All rates should survive deserialization.");
+            Assert.That(rates[0].PriceType, Is.EqualTo(UspsResponsePriceType.COMMERCIAL), "Known price types still parse.");
+            Assert.That(rates[1].PriceType, Is.Null, "Undocumented price type 'N' should deserialize to null.");
+            Assert.That(rates[1].DestinationEntryFacilityType, Is.Null, "Unknown facility type should deserialize to null.");
+            Assert.That(rates[1].Price, Is.EqualTo(7.55), "The rest of the rate should still be populated.");
+        }
+    }
+
+    [Test]
+    public void GetDomesticShippingOptions_WithUnknownPriceType_DoesNotThrowAndKeepsRates()
+    {
+        const string json = """
+        {
+            "originZIPCode": "38732",
+            "destinationZIPCode": "98052",
+            "pricingOptions": [
+                {
+                    "priceType": "N",
+                    "shippingOptions": [
+                        {
+                            "mailClass": "USPS_GROUND_ADVANTAGE",
+                            "rateOptions": [
+                                {
+                                    "totalPrice": 7.55,
+                                    "totalBasePrice": 7.55,
+                                    "rates": [
+                                        {
+                                            "description": "USPS Marketing Mail Nonprofit",
+                                            "SKU": "NPGA0",
+                                            "price": 7.55,
+                                            "priceType": "N"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        """;
+
+        UspsShippingOptionsResponse? response = null;
+        Assert.DoesNotThrow(() =>
+            response = JsonSerializer.Deserialize<UspsShippingOptionsResponse>(json));
+
+        Assert.That(response, Is.Not.Null);
+        var pricingOption = response!.PricingOptions![0];
+        var rate = pricingOption.Options![0].RateOptions![0].Rates![0];
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(pricingOption.PriceType, Is.Null, "Unknown option price type 'N' should deserialize to null.");
+            Assert.That(rate.PriceType, Is.Null, "Unknown rate price type 'N' should deserialize to null.");
+            Assert.That(rate.Price, Is.EqualTo(7.55), "The rest of the rate should still be populated.");
+        }
+    }
+}

--- a/ShippingRates/Models/Usps/UspsPricesResponse.cs
+++ b/ShippingRates/Models/Usps/UspsPricesResponse.cs
@@ -55,11 +55,15 @@ internal sealed class UspsRateDetails
     public string? Description { get; set; }
 
     /// <summary>
-    /// Price type: RETAIL, COMMERCIAL, etc.
+    /// Price type: RETAIL, COMMERCIAL, etc. USPS's published Domestic Prices spec
+    /// defines a fixed set (RETAIL, COMMERCIAL, COMMERCIAL_BASE, COMMERCIAL_PLUS,
+    /// CONTRACT, NSA), but the live API sometimes returns out-of-spec tokens (e.g.
+    /// "N"), which appears to be a USPS defect. Such values deserialize to null so
+    /// the rate is preserved instead of failing the whole response.
     /// </summary>
     [JsonPropertyName("priceType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public UspsResponsePriceType PriceType { get; set; }
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsResponsePriceType>))]
+    public UspsResponsePriceType? PriceType { get; set; }
 
     /// <summary>
     /// The postage price.
@@ -138,10 +142,11 @@ internal sealed class UspsRateDetails
     public string? RateIndicator { get; set; }
 
     /// <summary>
-    /// Destination Entry Facility type.
+    /// Destination Entry Facility type. Null when USPS returns a value outside
+    /// <see cref="UspsDestinationEntryFacilityType"/>.
     /// </summary>
     [JsonPropertyName("destinationEntryFacilityType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsDestinationEntryFacilityType>))]
     public UspsDestinationEntryFacilityType? DestinationEntryFacilityType { get; set; }
 }
 
@@ -181,11 +186,15 @@ internal sealed class UspsExtraRateDetails
     public double Price { get; set; }
 
     /// <summary>
-    /// Price type: RETAIL, COMMERCIAL, etc.
+    /// Price type: RETAIL, COMMERCIAL, etc. USPS's published Domestic Prices spec
+    /// defines a fixed set (RETAIL, COMMERCIAL, COMMERCIAL_BASE, COMMERCIAL_PLUS,
+    /// CONTRACT, NSA), but the live API sometimes returns out-of-spec tokens (e.g.
+    /// "N"), which appears to be a USPS defect. Such values deserialize to null so
+    /// the rate is preserved instead of failing the whole response.
     /// </summary>
     [JsonPropertyName("priceType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public UspsResponsePriceType PriceType { get; set; }
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsResponsePriceType>))]
+    public UspsResponsePriceType? PriceType { get; set; }
 
     /// <summary>
     /// Extra service code (370, 813, 820, etc.).
@@ -210,6 +219,13 @@ internal sealed class UspsExtraRateDetails
 
 #region Enums
 
+/// <summary>
+/// Price types documented in USPS's Domestic and International Prices specs.
+/// USPS occasionally returns out-of-spec values (e.g. "N") that are not defined
+/// here; those are treated as null by the response converters rather than added
+/// as members, since they violate USPS's own published contract.
+/// The deprecated "NSA" value is intentionally omitted for the same reason.
+/// </summary>
 [JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UspsResponsePriceType
 {

--- a/ShippingRates/Models/Usps/UspsShippingOptionsResponse.cs
+++ b/ShippingRates/Models/Usps/UspsShippingOptionsResponse.cs
@@ -22,8 +22,8 @@ internal class UspsDomesticPricingOption
     [JsonPropertyName("shippingOptions")]
     public UspsDomesticOptions[]? Options { get; set; }
     [JsonPropertyName("priceType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public UspsResponsePriceType PriceType { get; set; }
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsResponsePriceType>))]
+    public UspsResponsePriceType? PriceType { get; set; }
 }
 
 internal class UspsDomesticOptions
@@ -80,8 +80,8 @@ internal class UspsDomesticRate
     [JsonPropertyName("dimWeight")]
     public double DimWeight { get; set; }
     [JsonPropertyName("priceType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public UspsResponsePriceType PriceType { get; set; }
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsResponsePriceType>))]
+    public UspsResponsePriceType? PriceType { get; set; }
     [JsonPropertyName("fees")]
     public List<UspsRateFee>? Fees { get; set; }
     [JsonPropertyName("productName")]
@@ -94,7 +94,7 @@ internal class UspsDomesticRate
     [JsonPropertyName("rateIndicator")]
     public string? RateIndicator { get; set; }
     [JsonPropertyName("destinationEntryFacilityType")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
+    [JsonConverter(typeof(NullableEnumJsonConverter<UspsDestinationEntryFacilityType>))]
     public UspsDestinationEntryFacilityType? DestinationEntryFacilityType { get; set; }
     [JsonPropertyName("mailClass")]
     public string? MailClass { get; set; }


### PR DESCRIPTION
## Problem

USPS Domestic Prices v3 occasionally returns a `priceType` value that is **not**
part of USPS's own published enum (`RETAIL`, `COMMERCIAL`, `COMMERCIAL_BASE`,
`COMMERCIAL_PLUS`, `CONTRACT`, `NSA`). In production we observed `"priceType":"N"`
on `MARKETING_MAIL_PARCELS` rates — a value absent from the USPS Prices OpenAPI
spec (v3.4.31), so it appears to be a USPS-side defect.

The response DTOs decorate `priceType` with a strict `JsonStringEnumConverter`,
which **throws** on the unknown token. Because System.Text.Json aborts the whole
deserialization, a single out-of-spec value causes the **entire rate response to
fail and every rate to be dropped**.

## Fix

Be liberal in what the client accepts: switch the response-side `priceType` (and
`destinationEntryFacilityType`) properties to nullable and deserialize them with
the existing `NullableEnumJsonConverter<TEnum>` — the same converter already used
for `ProcessingCategory`. Unknown/out-of-spec tokens now map to `null` and the
rate is preserved.

## Notes

- Affected DTOs are `internal`; the response-side `PriceType` is not read by any
  provider logic, so there is no public API behavior change.
- Documented `priceType` values continue to parse to their enum member.
- `"N"` / `NSA` are intentionally **not** added as enum members — `"N"` is
  undocumented (a USPS contract violation) and `NSA` is deprecated; both are
  covered by the null-tolerant path.

## Tests

Adds `UspsResponsePriceTypeDeserializationTests` covering both the Domestic Prices
and Domestic Shipping Options responses: documented values parse, out-of-spec
tokens map to null, and rates are preserved. Full suite: **54 passed / 0 failed**.